### PR TITLE
Add basic docs, drop split-at

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ext/sphinx-extensions"]
+	path = ext/sphinx-extensions
+	url = https://github.com/dylan-lang/sphinx-extensions

--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/documentation/make.bat
+++ b/documentation/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/documentation/source/collection-utilities.rst
+++ b/documentation/source/collection-utilities.rst
@@ -1,0 +1,38 @@
+The collection-utilities Module
+===============================
+
+.. current-library:: collection-extensions
+.. current-module:: collection-utilities
+
+Reference
+---------
+
+**TODO**: These docs are just an auto-generated skeleton so
+far. https://github.com/dylan-lang/collection-extensions/issues/2
+
+.. generic-function:: key-exists?
+
+   :signature: key-exists? (collection key) => (key-exists? value)
+
+   :parameter collection: An instance of :drm:`<collection>`.
+   :parameter key: An instance of :drm:`<object>`.
+   :value key-exists?: An instance of :drm:`<boolean>`.
+   :value value: An instance of :drm:`<object>`.
+
+.. generic-function:: singleton?
+   :open:
+
+   :signature: singleton? (collection) => (singleton?)
+
+   :parameter collection: An instance of :drm:`<collection>`.
+   :value singleton?: An instance of :drm:`<boolean>`.
+
+.. method:: singleton?
+   :specializer: <collection>
+
+.. method:: singleton?
+   :specializer: <pair>
+
+.. method:: singleton?
+   :specializer: <empty-list>
+

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -1,0 +1,73 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../ext/sphinx-extensions/sphinxcontrib'))
+import dylan.themes as dylan_themes
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Collection Extensions'
+copyright = '1998, 1999, 2000  Gwydion Dylan Maintainers'
+
+# The full version, including alpha/beta/rc tags
+release = 'v0.2.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'dylan.domain',
+    'sphinx.ext.intersphinx'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build']
+
+# This makes it so that each document doesn't have to use
+#   .. default-domain:: dylan
+# but they probably should anyway, so that they can be built separately
+# without depending on this top-level config file.
+primary_domain = 'dylan'
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+html_theme = dylan_themes.get_html_theme_default()
+
+# Theme options are theme-specific and customize the look and feel of a theme
+# further.  For a list of options available for each theme, see the
+# documentation.
+html_theme_options = dylan_themes.get_html_theme_options_default()
+
+# Add any paths that contain custom themes here, relative to this directory.
+html_theme_path = [dylan_themes.get_html_theme_path()]
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+html_title = "Collection Extensions"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/documentation/source/heap.rst
+++ b/documentation/source/heap.rst
@@ -1,0 +1,92 @@
+The heap Module
+===============
+
+Overview
+--------
+
+A heap is an implementation of the abstract data type "sorted list". A heap
+is a sorted sequence of items.  Most likely the user will end up writing
+something like
+
+.. code-block:: dylan
+
+   define class <heap-item> (<object>)
+     slot priority;
+     slot data;
+   end;
+
+with appropriate methods defined for :drm:`<` and :drm:`=`. The user could,
+however, have simply a sorted list of integers, or have some item where the
+priority is an integral part of the item itself.
+
+:drm:`make` on heaps supports the ``less-than:`` keyword, which supply the
+heap's comparison and defaults to :drm:`<`.
+
+Heaps support all the usual sequence operations. The most useful ones::
+
+     heap-push(heap, item) => updated-heap
+     heap-pop(heap)        => smallest-element
+     first(heap)           => smallest-element
+     second(heap)          => second-smallest-element
+     add!(heap, item)      => updated-heap
+     sort, sort!           => sorted-sequence
+
+These are all "efficient" operations (defined below).  As with :drm:`push` on
+:drm:`<deque>`, :func:`heap-push` is another name for :drm:`add!`, and does
+exactly the same thing except that heap-push doesn't accept any keywords.
+:drm:`sort` and :drm:`sort!` return a sequence that's not a heap. Not
+necessarily efficient but useful anyhow::
+
+     add-new!(heap, item, #key test:, efficient:) => updated-heap
+     remove!(heap, item, #key test:, efficient:) => updated-heap
+     member?(item, heap, #key test:, efficient:) => <boolean>
+
+The ``efficient:`` keyword defaults to ``#f``. If ``#t``, it uses the
+:func:`random-iteration-protocol` (which is considerably more efficient, but
+isn't really standard behavior, so it had to be optional).  Conceivably most
+sequence methods could support such a keyword, but they don't yet.
+
+The user can use :drm:`element-setter` or the iteration protocol to change an
+item in the heap, but changing the priority of an item is an error and Bad
+Things(tm) will happen. No error will be signaled.  Both of these operations
+are very inefficient.
+
+Heaps are **not** instances of :drm:`<stretchy-collection>`, although
+:drm:`add!` and :func:`heap-pop` can magically change the size of the heap.
+
+Efficiency: Approximate running times of different operations are given
+below: (N is the size of the heap) ::
+
+    first, first-setter                             O(1)
+    second (but not second-setter)                  O(1)
+    size                                            O(1)
+    add!                                            O(lg N)
+    heap-push                                       O(lg N)
+    heap-pop(heap)                                  O(lg N)
+    sort, sort!                                     O(N * lg N)
+    forward-iteration-protocol
+                            setup:                  O(N)
+                            next-state:             O(lg N)
+                            current-element:        O(1)
+                            current-element-setter: O(N)
+    backward-iteration-protocol
+                            setup:                  O(N * lg N)
+                            next-state:             O(1)
+                            current-element:        O(1)
+                            current-element-setter: O(N)
+    random-iteration-protocol
+                            setup:                  O(1)
+                            next-state:             O(1)
+                            current-element:        O(1)
+                            current-element-setter: O(1)
+    element(heap, M)                                O(M*lg N + N)
+    element-setter(value, heap, M)                  O(N + M*lg N + M)
+
+:drm:`element`, :drm:`element-setter` on arbitrary keys use the
+:drm:`forward-iteration-protocol` (via the inherited methods), and have
+accordingly bad performance.
+
+Reference
+---------
+
+**TODO**: https://github.com/dylan-lang/collection-extensions/issues/2

--- a/documentation/source/heap.rst
+++ b/documentation/source/heap.rst
@@ -1,6 +1,9 @@
 The heap Module
 ===============
 
+.. current-library:: collection-extensions
+.. current-module:: vector-search
+
 Overview
 --------
 
@@ -89,4 +92,44 @@ accordingly bad performance.
 Reference
 ---------
 
-**TODO**: https://github.com/dylan-lang/collection-extensions/issues/2
+The HEAP module
+***************
+
+.. current-module:: heap
+
+
+.. class:: <heap>
+
+   :superclasses: :drm:`<mutable-sequence>`
+
+   :keyword less-than: An instance of :drm:`<object>`.
+   :keyword size: An instance of :drm:`<object>`.
+
+.. generic-function:: heap-pop
+
+   :signature: heap-pop (h) => (smallest-item)
+
+   :parameter h: An instance of :class:`<heap>`.
+   :value smallest-item: An instance of :drm:`<object>`.
+
+.. generic-function:: heap-push
+
+   :signature: heap-push (h new-elt) => (changed-heap)
+
+   :parameter h: An instance of :class:`<heap>`.
+   :parameter new-elt: An instance of :drm:`<object>`.
+   :value changed-heap: An instance of :class:`<heap>`.
+
+.. generic-function:: random-iteration-protocol
+
+   :signature: random-iteration-protocol (collection) => (initial-state limit next-state finished-state? current-key current-element current-element-setter copy-state)
+
+   :parameter collection: An instance of :class:`<heap>`.
+   :value initial-state: An instance of :drm:`<object>`.
+   :value limit: An instance of :drm:`<object>`.
+   :value next-state: An instance of :drm:`<function>`.
+   :value finished-state?: An instance of :drm:`<function>`.
+   :value current-key: An instance of :drm:`<function>`.
+   :value current-element: An instance of :drm:`<function>`.
+   :value current-element-setter: An instance of :drm:`<function>`.
+   :value copy-state: An instance of :drm:`<function>`.

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -1,0 +1,21 @@
+*********************
+Collection Extensions
+*********************
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   heap
+   sde-vector
+   sequence-diff
+   sequence-utilities
+   self-organizing-list
+   string-search
+   subseq
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`search`

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -1,18 +1,21 @@
-*********************
-Collection Extensions
-*********************
+*********************************
+The collection-extensions Library
+*********************************
+
+.. current-library:: collection-extensions
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Contents:
 
+   collection-utilities
    heap
    sde-vector
+   self-organizing-list
    sequence-diff
    sequence-utilities
-   self-organizing-list
-   string-search
    subseq
+   vector-search
 
 Indices and tables
 ==================

--- a/documentation/source/sde-vector.rst
+++ b/documentation/source/sde-vector.rst
@@ -1,0 +1,26 @@
+The sde-vector Module
+=====================
+
+.. current-library:: collection-extensions
+.. current-module:: sde-vector
+
+Overview
+--------
+
+Stretchy double ended vector -- A collection that has keys from -n to n, where
+n is a non-negative integer.  It's not technically a vector because the keys
+don't start at 0, and so doesn't inherit a lot of sequence methods, but
+otherwise it behaves like a vector.
+
+
+Reference
+---------
+
+**TODO**: https://github.com/dylan-lang/collection-extensions/issues/2
+
+.. class:: <sde-vector>
+
+   :superclasses: :drm:`<mutable-collection>`, :drm:`<stretchy-collection>`
+
+   :keyword fill: An instance of :drm:`<object>`.
+   :keyword size: An instance of :drm:`<object>`.

--- a/documentation/source/self-organizing-list.rst
+++ b/documentation/source/self-organizing-list.rst
@@ -1,0 +1,12 @@
+The self-organizing-list Module
+===============================
+
+.. current-library:: collection-extensions
+.. current-module:: self-organizing-list
+
+
+.. class:: <self-organizing-list>
+
+   :superclasses: :drm:`<mutable-explicit-key-collection>`, :drm:`<stretchy-collection>`
+
+   :keyword test: An instance of :drm:`<function>`.

--- a/documentation/source/sequence-diff.rst
+++ b/documentation/source/sequence-diff.rst
@@ -1,0 +1,73 @@
+The sequence-diff Module
+========================
+
+.. current-library:: collection-extensions
+.. current-module:: sequence-diff
+
+
+Overview
+--------
+
+The sequence-diff module implements an algorithm that accomplishes something
+similar to the Unix diff utility.  (Your actual diff utility may or may not use
+this algorithm, but it does something similar.)
+
+Algorithm is by Webb Miller and Eugene W. Myers, published as "A File
+Comparison Program", p.  1025-1040 of Software--Practice and Experience,
+November 1985.  Quite frankly the algorithm is rather incomprehensible in
+source code form, so you might want to think about getting the paper.
+
+
+Reference
+---------
+
+**TODO**: These docs are just an auto-generated skeleton so
+far. https://github.com/dylan-lang/collection-extensions/issues/2
+
+.. class:: <delete-entry>
+
+   :superclasses: :class:`<script-entry>`
+
+
+.. class:: <insert-entry>
+
+   :superclasses: :class:`<script-entry>`
+
+   :keyword required source-index: An instance of :drm:`<object>`.
+
+.. class:: <script-entry>
+   :abstract:
+
+   :superclasses: :drm:`<object>`
+
+   :keyword count: An instance of :drm:`<object>`.
+   :keyword required dest-index: An instance of :drm:`<object>`.
+
+.. generic-function:: dest-index
+
+   :signature: dest-index (object) => (value)
+
+   :parameter object: An instance of :class:`<script-entry>`.
+   :value value: An instance of :drm:`<object>`.
+
+.. generic-function:: element-count
+
+   :signature: element-count (object) => (value)
+
+   :parameter object: An instance of :class:`<script-entry>`.
+   :value value: An instance of :drm:`<object>`.
+
+.. generic-function:: sequence-diff
+
+   :signature: sequence-diff (s1 s2) => (script)
+
+   :parameter s1: An instance of :drm:`<sequence>`.
+   :parameter s2: An instance of :drm:`<sequence>`.
+   :value script: An instance of :const:`<script>`.
+
+.. generic-function:: source-index
+
+   :signature: source-index (object) => (value)
+
+   :parameter object: An instance of :class:`<insert-entry>`.
+   :value value: An instance of :drm:`<object>`.

--- a/documentation/source/sequence-utilities.rst
+++ b/documentation/source/sequence-utilities.rst
@@ -1,0 +1,365 @@
+The sequence-utilities Module
+=============================
+
+.. current-library:: collection-extensions
+.. current-module:: sequence-utilities
+
+Overview
+--------
+
+The sequence-utilities module implements some useful methods on sequences.
+
+
+Reference
+---------
+
+**TODO**: These docs are just an auto-generated skeleton so
+far. https://github.com/dylan-lang/collection-extensions/issues/2
+
+.. function:: alist-copy
+
+   :signature: alist-copy (alist #key key datum cons) => (new-alist)
+
+   :parameter alist: An instance of :drm:`<sequence>`.
+   :parameter #key key: An instance of :drm:`<object>`.
+   :parameter #key datum: An instance of :drm:`<object>`.
+   :parameter #key cons: An instance of :drm:`<object>`.
+   :value new-alist: An instance of :drm:`<sequence>`.
+
+.. function:: alist-delete
+
+   :signature: alist-delete (elt alist #key key test) => (#rest results)
+
+   :parameter elt: An instance of :drm:`<object>`.
+   :parameter alist: An instance of :drm:`<sequence>`.
+   :parameter #key key: An instance of :drm:`<object>`.
+   :parameter #key test: An instance of :drm:`<object>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. function:: apair
+
+   :signature: apair (key datum aseq #key cons add) => (new-aseq)
+
+   :parameter key: An instance of :drm:`<object>`.
+   :parameter datum: An instance of :drm:`<object>`.
+   :parameter aseq: An instance of :drm:`<sequence>`.
+   :parameter #key cons: An instance of :drm:`<object>`.
+   :parameter #key add: An instance of :drm:`<object>`.
+   :value new-aseq: An instance of :drm:`<sequence>`.
+
+.. function:: assoc
+
+   :signature: assoc (elt seq #key key test) => (#rest results)
+
+   :parameter elt: An instance of :drm:`<object>`.
+   :parameter seq: An instance of :drm:`<sequence>`.
+   :parameter #key key: An instance of :drm:`<object>`.
+   :parameter #key test: An instance of :drm:`<object>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. generic-function:: choose-map
+
+   :signature: choose-map (pred func seq #rest seqs) => (#rest results)
+
+   :parameter pred: An instance of :drm:`<object>`.
+   :parameter func: An instance of :drm:`<object>`.
+   :parameter seq: An instance of :drm:`<object>`.
+   :parameter #rest seqs: An instance of :drm:`<object>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. method:: choose-map
+   :specializer: <function>, <function>, <sequence>
+
+.. method:: choose-map
+   :specializer: <function>, <function>, <list>
+
+.. generic-function:: concatenate-map
+
+   :signature: concatenate-map (func seq #rest seqs) => (#rest results)
+
+   :parameter func: An instance of :drm:`<object>`.
+   :parameter seq: An instance of :drm:`<object>`.
+   :parameter #rest seqs: An instance of :drm:`<object>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. method:: concatenate-map
+   :specializer: <function>, <sequence>
+
+.. method:: concatenate-map
+   :specializer: <function>, <list>
+
+.. generic-function:: drop
+   :open:
+
+   :signature: drop (collection k) => (#rest results)
+
+   :parameter collection: An instance of :drm:`<object>`.
+   :parameter k: An instance of :drm:`<integer>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. method:: drop
+   :specializer: <sequence>, <integer>
+
+.. generic-function:: find
+
+   :signature: find (pred seq #key failure) => (#rest results)
+
+   :parameter pred: An instance of :drm:`<function>`.
+   :parameter seq: An instance of :drm:`<sequence>`.
+   :parameter #key failure: An instance of :drm:`<object>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. generic-function:: find-tail
+
+   :signature: find-tail (pred seq) => (#rest results)
+
+   :parameter pred: An instance of :drm:`<object>`.
+   :parameter seq: An instance of :drm:`<object>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. method:: find-tail
+   :specializer: <function>, <sequence>
+
+.. method:: find-tail
+   :specializer: <function>, <pair>
+
+.. method:: find-tail
+   :specializer: <function>, <empty-list>
+
+.. function:: foldl
+
+   :signature: foldl (cons nil lst) => (#rest results)
+
+   :parameter cons: An instance of :drm:`<function>`.
+   :parameter nil: An instance of :drm:`<object>`.
+   :parameter lst: An instance of :drm:`<list>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. function:: foldr
+
+   :signature: foldr (cons nil lst) => (#rest results)
+
+   :parameter cons: An instance of :drm:`<function>`.
+   :parameter nil: An instance of :drm:`<object>`.
+   :parameter lst: An instance of :drm:`<list>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. function:: heads
+
+   :signature: heads (lists) => (new-list)
+
+   :parameter lists: An instance of :drm:`<list>`.
+   :value new-list: An instance of :drm:`<list>`.
+
+.. generic-function:: index
+
+   :signature: index (elt seq #key test failure) => (index)
+
+   :parameter elt: An instance of :drm:`<object>`.
+   :parameter seq: An instance of :drm:`<sequence>`.
+   :parameter #key test: An instance of :drm:`<object>`.
+   :parameter #key failure: An instance of :drm:`<object>`.
+   :value index: An instance of :drm:`<object>`.
+
+.. function:: last-pair
+
+   :signature: last-pair (lst) => (last-pair)
+
+   :parameter lst: An instance of :drm:`<pair>`.
+   :value last-pair: An instance of :drm:`<pair>`.
+
+.. function:: list*
+
+   :signature: list* (#rest rest) => (new-list)
+
+   :parameter #rest rest: An instance of :drm:`<object>`.
+   :value new-list: An instance of :drm:`<list>`.
+
+.. generic-function:: list?
+
+   :signature: list? (arg) => (#rest results)
+
+   :parameter arg: An instance of :drm:`<object>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. method:: list?
+   :specializer: <list>
+
+.. method:: list?
+   :specializer: <object>
+
+.. generic-function:: null?
+
+   :signature: null? (arg) => (#rest results)
+
+   :parameter arg: An instance of :drm:`<object>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. method:: null?
+   :specializer: <empty-list>
+
+.. method:: null?
+   :specializer: <object>
+
+.. function:: pair-do
+
+   :signature: pair-do (func lst #rest lists) => (false)
+
+   :parameter func: An instance of :drm:`<function>`.
+   :parameter lst: An instance of :drm:`<list>`.
+   :parameter #rest lists: An instance of :drm:`<object>`.
+   :value false: An instance of :drm:`<boolean>`.
+
+.. function:: pair-foldl
+
+   :signature: pair-foldl (cons nil lst) => (#rest results)
+
+   :parameter cons: An instance of :drm:`<function>`.
+   :parameter nil: An instance of :drm:`<object>`.
+   :parameter lst: An instance of :drm:`<list>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. function:: pair-foldr
+
+   :signature: pair-foldr (cons nil lst) => (#rest results)
+
+   :parameter cons: An instance of :drm:`<function>`.
+   :parameter nil: An instance of :drm:`<object>`.
+   :parameter lst: An instance of :drm:`<list>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. generic-function:: pair?
+
+   :signature: pair? (arg) => (#rest results)
+
+   :parameter arg: An instance of :drm:`<object>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. method:: pair?
+   :specializer: <pair>
+
+.. method:: pair?
+   :specializer: <object>
+
+.. function:: partition
+
+   :signature: partition (pred seq) => (winners losers)
+
+   :parameter pred: An instance of :drm:`<function>`.
+   :parameter seq: An instance of :drm:`<sequence>`.
+   :value winners: An instance of :drm:`<list>`.
+   :value losers: An instance of :drm:`<list>`.
+
+.. macro:: pop!
+
+.. generic-function:: precedes?
+
+   :signature: precedes? (elt-1 elt-2 seq #key test not-found) => (precedes?)
+
+   :parameter elt-1: An instance of :drm:`<object>`.
+   :parameter elt-2: An instance of :drm:`<object>`.
+   :parameter seq: An instance of :drm:`<sequence>`.
+   :parameter #key test: An instance of :drm:`<object>`.
+   :parameter #key not-found: An instance of :drm:`<object>`.
+   :value precedes?: An instance of :drm:`<boolean>`.
+
+.. macro:: push!
+
+.. function:: reduce-l
+
+   :signature: reduce-l (cons nil lst) => (#rest results)
+
+   :parameter cons: An instance of :drm:`<function>`.
+   :parameter nil: An instance of :drm:`<object>`.
+   :parameter lst: An instance of :drm:`<list>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. function:: reduce-r
+
+   :signature: reduce-r (cons nil lst) => (#rest results)
+
+   :parameter cons: An instance of :drm:`<function>`.
+   :parameter nil: An instance of :drm:`<object>`.
+   :parameter lst: An instance of :drm:`<list>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. generic-function:: reverse-append
+   :open:
+
+   :signature: reverse-append (reversed-head tail) => (new-sequence)
+
+   :parameter reversed-head: An instance of :drm:`<sequence>`.
+   :parameter tail: An instance of :drm:`<sequence>`.
+   :value new-sequence: An instance of :drm:`<sequence>`.
+
+.. method:: reverse-append
+   :specializer: <sequence>, <sequence>
+
+.. method:: reverse-append
+   :specializer: <list>, <list>
+
+.. generic-function:: satisfies
+
+   :signature: satisfies (pred seq #key failure) => (index)
+
+   :parameter pred: An instance of :drm:`<function>`.
+   :parameter seq: An instance of :drm:`<sequence>`.
+   :parameter #key failure: An instance of :drm:`<object>`.
+   :value index: An instance of :drm:`<object>`.
+
+.. function:: tabulate
+
+   :signature: tabulate (length func #key type) => (#rest results)
+
+   :parameter length: An instance of :drm:`<integer>`.
+   :parameter func: An instance of :drm:`<function>`.
+   :parameter #key type: An instance of :drm:`<object>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. function:: tails
+
+   :signature: tails (lists) => (#rest results)
+
+   :parameter lists: An instance of :drm:`<list>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. generic-function:: take
+   :open:
+
+   :signature: take (collection k) => (#rest results)
+
+   :parameter collection: An instance of :drm:`<object>`.
+   :parameter k: An instance of :drm:`<integer>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. method:: take
+   :specializer: <sequence>, <integer>
+
+.. function:: unfold
+
+   :signature: unfold (pred f g seed) => (new-list)
+
+   :parameter pred: An instance of :drm:`<function>`.
+   :parameter f: An instance of :drm:`<function>`.
+   :parameter g: An instance of :drm:`<function>`.
+   :parameter seed: An instance of :drm:`<object>`.
+   :value new-list: An instance of :drm:`<list>`.
+
+.. function:: unfold/tail
+
+   :signature: unfold/tail (pred f g e seed) => (new-list)
+
+   :parameter pred: An instance of :drm:`<function>`.
+   :parameter f: An instance of :drm:`<function>`.
+   :parameter g: An instance of :drm:`<function>`.
+   :parameter e: An instance of :drm:`<function>`.
+   :parameter seed: An instance of :drm:`<object>`.
+   :value new-list: An instance of :drm:`<list>`.
+
+.. function:: xpair
+
+   :signature: xpair (list elt) => (new-list)
+
+   :parameter list: An instance of :drm:`<list>`.
+   :parameter elt: An instance of :drm:`<object>`.
+   :value new-list: An instance of :drm:`<list>`.

--- a/documentation/source/subseq.rst
+++ b/documentation/source/subseq.rst
@@ -1,0 +1,108 @@
+The subseq Module
+=================
+
+.. current-library:: collection-extensions
+.. current-module:: subseq
+
+Overview
+--------
+
+:class:`<subsequence>` is a new subclass of :drm:`<sequence>`.  A subsequence
+represents an aliased reference to some part of an existing sequence.  Although
+they may be created by :drm:`make` (with required keywords ``source:``,
+``start:`` and ``end:``) on one of the instantiable subclasses, they are more
+often created by calls of the form
+
+.. code-block:: dylan
+
+   subsequence(sequence, start: 0, end: 3)
+
+where ``start:`` and ``end:`` are optional keywords which default to the
+beginning and end, respectively, of the source sequence.  No other new
+operations are defined for subsequences, since all necessary operations are
+inherited from :drm:`<sequence>`.
+
+Because subsequences are aliased references into other sequences, several
+properties must be remembered:
+
+1. The contents of a subsequence are undefined after any destructive operation
+   upon the source sequence.
+
+2. Destructive operations upon subsequences may be reflected in the source.
+   The results of reverse! and sort! should be expected to affect the source
+   sequence for vector subsequences.
+
+If the source sequences are instances of :drm:`<vector>` or :drm:`<string>`,
+then the implementation will use subclasses of :class:`<subsequence>` which are
+also subclasses of :drm:`<vector>` or :drm:`<string>`.
+
+Efficiency notes:
+
+1. The implementation tries to insure that subsequences of subsequences
+   can be accessed as efficiently as the original subsequence.  (For
+   example, the result of
+
+   .. code-block:: dylan
+
+      subsequence(subsequence(source, start: 1), start: 2)
+
+   would produce a subsequence identical to the one produced by
+
+   .. code-block:: dylan
+
+      subsequence(source, start: 3)
+
+2. Vector subsequences, like all other vectors, implement constant time element
+   access.
+
+3. Non-vector subsequences may take non-constant time to create, but will
+   provide constant-time access to the first element.  This should produce the
+   best performance provided some element of the subsequence is accessed at
+   least once.
+
+
+Reference
+---------
+
+.. class:: <byte-vector-subsequence>
+
+   :superclasses: :class:`<vector-subsequence>`
+
+
+.. class:: <subsequence>
+   :abstract:
+
+   :superclasses: :drm:`<sequence>`
+
+   :keyword required end: An instance of :drm:`<integer>`.
+   :keyword required source: An instance of :drm:`<sequence>`.
+   :keyword required start: An instance of :drm:`<integer>`.
+
+.. generic-function:: subsequence
+
+   :signature: subsequence (seq) => (#rest results)
+
+   :parameter seq: An instance of :drm:`<object>`.
+   :value #rest results: An instance of :drm:`<object>`.
+
+.. method:: subsequence
+   :specializer: <subsequence>
+
+.. method:: subsequence
+   :specializer: <sequence>
+
+.. method:: subsequence
+   :specializer: <generic-subsequence>
+
+.. method:: subsequence
+   :specializer: <vector>
+
+.. method:: subsequence
+   :specializer: <byte-vector>
+
+.. method:: subsequence
+   :specializer: <byte-vector-subsequence>
+
+.. method:: subsequence
+   :specializer: <string>
+

--- a/documentation/source/vector-search.rst
+++ b/documentation/source/vector-search.rst
@@ -1,0 +1,48 @@
+The vector-search Module
+========================
+
+.. current-library:: collection-extensions
+.. current-module:: vector-search
+
+Overview
+--------
+
+The *vector-search* module provides basic search and replace capabilities upon
+restricted subsets of :drm:`<sequence>` -- primarily :drm:`<vector>`.
+Exploiting the known properties of these types yields substantially better
+performance than can be achieved for sequences in general.
+
+Reference
+---------
+
+.. generic-function:: find-first-key
+
+   :signature: find-first-key (seq pred? #key start end failure) => (#rest results)
+
+   :parameter seq: An instance of :class:`<vector>`.
+   :parameter pred?: An instance of :class:`<function>`.
+   :parameter #key start: An instance of :class:`<object>`.
+   :parameter #key end: An instance of :class:`<object>`.
+   :parameter #key failure: An instance of :class:`<object>`.
+   :value #rest results: An instance of :class:`<object>`.
+
+   :discussion:
+
+     Find the index of the first element (after ``start`` but before ``end``)
+     of a vector which satisfies the given predicate.  If no matching element
+     is found, return the ``failure`` value.  The defaults for start, end and
+     failure are, respectively, 0, size(vector), and #f.  This function is like
+     :drm:`find-key`, but accepts ``start:`` and ``end:`` rather than
+     ``skip:``.
+
+
+.. generic-function:: find-last-key
+
+   :signature: find-last-key (seq pred? #key start end failure) => (#rest results)
+
+   :parameter seq: An instance of :class:`<vector>`.
+   :parameter pred?: An instance of :class:`<function>`.
+   :parameter #key start: An instance of :class:`<object>`.
+   :parameter #key end: An instance of :class:`<object>`.
+   :parameter #key failure: An instance of :class:`<object>`.
+   :value #rest results: An instance of :class:`<object>`.

--- a/library.dylan
+++ b/library.dylan
@@ -100,6 +100,5 @@ define module sequence-utilities
   export concatenate-map, pair-do, choose-map;
   export partition, assoc, apair, alist-copy, alist-delete;
   export satisfies, index, find, find-tail, precedes?;
-  export split-at;
 end module sequence-utilities;
 

--- a/sequence-utils.dylan
+++ b/sequence-utils.dylan
@@ -588,27 +588,3 @@ define method precedes?(elt-1, elt-2, seq :: <sequence>,
     not-found;
   end block;
 end method precedes?;
-
-// SPLIT-AT -- split a sequence at a token.
-//
-// Replace with common-dylan:split.  --cgay
-define function split-at
-    (sequence :: <sequence>, token, #key test = \=)
- => split-sequence :: <sequence>;
-  let result = make(<stretchy-vector>);
-  let current-item = make(<stretchy-vector>);
-  for (elt in sequence)
-    if (test(elt, token))
-      add!(result, current-item);
-      current-item := make(<stretchy-vector>);
-    else
-      add!(current-item, elt);
-    end if;
-  finally
-    // Add the last part.  If the line ends with Token we add
-    // an empty sequence.
-    add!(result, current-item);
-  end for;
-  result;
-end function split-at;
-

--- a/tests/sequence-utils-suite.dylan
+++ b/tests/sequence-utils-suite.dylan
@@ -41,57 +41,8 @@ define test pop-test (description: "Pop! macro")
   check-equal("Pop singleton location", x, #());
 end test pop-test;
 
-define test split-empty-vector
-    (description: "Split-at called on an empty vector")
-  let result = split-at(#(), ',');
-  check("Split of empty list is singleton", singleton?, result);
-  check("Split of empty list has empty member", empty?, result[0]);
-end test split-empty-vector;
-
-define test split-string-1
-    (description: "Split a string without commas")
-  let result = split-at("abc", ',');
-  check("Split is singleton", singleton?, result);
-  check-equal("Member equal to whole string", as(<string>, result[0]), "abc");
-end test split-string-1;
-
-define test split-string-2
-    (description: "Split a string with 2 commas")
-  let result = split-at("a,bc,def", ',');
-  check-equal("Split contains three elements", 3, result.size);
-  check-equal("First string is \"a\"", "a", result[0]);
-  check-equal("Second string is \"bc\"", "bc", result[1]);
-  check-equal("Thrid string is \"def\"", "def", result[2]);
-end test split-string-2;
-
-define test split-string-3
-    (description: "Split a string with trailing comma")
-  let result = split-at("a,bc,def,", ',');
-  check-equal("Split contains four elements", 4, result.size);
-  check-equal("First string is \"a\"", "a", result[0]);
-  check-equal("Second string is \"bc\"", "bc", result[1]);
-  check-equal("Thrid string is \"def\"", "def", result[2]);
-  check-equal("Thrid string is empty", "", result[3]);
-end test split-string-3;
-
-define test split-string-4
-    (description: "Split a string with 3 semicolons")
-  let result = split-at("\"a A\";\"b B\";c;d", ';');
-  check-equal("Split contains three elements", 4, result.size);
-  check-equal("First string is \"a A\"", "\"a A\"", result[0]);
-  check-equal("Second string is \"b B\"", "\"b B\"", result[1]);
-  check-equal("Thrid string is \"c\"", "c", result[2]);
-  check-equal("Thrid string is \"d\"", "d", result[3]);
-end test split-string-4;
-
-
 define suite sequence-utilities-suite
     (description: "Test suite for the sequence-utilities module.")
   test push-test;
   test pop-test;
-  test split-empty-vector;
-  test split-string-1;
-  test split-string-2;
-  test split-string-3;
-  test split-string-4;
 end suite sequence-utilities-suite;


### PR DESCRIPTION
This adds very basic docs for the collection-extensions library. I also dropped the `split-at` function because no one was using it and we now have `split` in common-dylan, a direct replacement.