### PR TITLE
Refurbish library

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/buid-documentation.yml
+++ b/.github/workflows/buid-documentation.yml
@@ -1,0 +1,54 @@
+name: Build documentation
+
+on:
+  push:
+    # all branches
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+# https://github.com/JamesIves/github-pages-deploy-action#readme
+permissions:
+    contents: write
+
+# Set DYLAN environment variable to GITHUB_WORKSPACE so packages are
+# installed in ../../_packages relative to documentation's Makefile
+env:
+  DYLAN: ${{ github.workspace }}
+
+jobs:
+
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check links
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/fraya/dylan-docs
+          options: -v ${{ github.workspace }}/documentation:/docs
+          run: make linkcheck
+
+      - name: Build docs with Furo theme
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/fraya/dylan-docs
+          options: -v ${{ github.workspace }}/documentation:/docs
+          run: make html
+
+      - name: Upload html artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: collection-extensions-github-io-html
+          path: documentation/build/html/
+
+      - name: Bypassing Jekyll on GH Pages
+        run: sudo touch documentation/build/html/.nojekyll
+
+      - name: Deploy docs to GH pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/build/html

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,35 @@
+name: Build and test
+
+on:
+  push:
+    # all branches
+  pull_request:
+    # all branches
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Opendylan
+        uses: dylan-lang/install-opendylan@v3
+
+      - name: Download dependencies
+        run: dylan update
+
+      - name: Build tests
+        run: dylan build collection-extensions-test-suite-app
+
+      - name: Run tests
+        run: _build/bin/collection-extensions-test-suite-app --progress none --report surefire > _build/TEST-collection-extensions.xml
+
+      - name: Publish Test Report
+        if: success() || failure()
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: '**/_build/TEST-*.xml'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,19 @@
+# backup files
+*~
+*.bak
+.DS_Store
+
+# project file
 *.hdp
-_build
+
+# documentation build directory
+build/
+
+# compiler build directory
+_build/
+
+# dylan tool package cache
+_packages/
+
+# package registry folder
+registry/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ext/sphinx-extensions"]
-	path = ext/sphinx-extensions
-	url = https://github.com/dylan-lang/sphinx-extensions

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# Copyright.
+
+Copyright (C) 2004 Dr. Matthias Hölzl.
+
+Use and copying of this software and preparation of derivative works
+based on this software are permitted, including commercial use,
+provided that the following conditions are observed:
+
+1. This copyright notice must be retained in full on any copies and on
+   appropriate parts of any derivative works. (Other names and years
+   may be added, so long as no existing ones are removed.)
+
+This software is made available "as is".  Neither the authors nor
+Carnegie Mellon University make any warranty about the software, its
+performance, or its conformity to any specification.
+
+Bug reports, questions, comments, and suggestions should be sent by
+E-mail to the Internet address "dylan-lang@googlegroups.com".
+
+If you need to receive this library under another license contact the
+author (tc@xantira.com).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Collection extensions
+[![Build and test](https://github.com/dylan-lang/collection-extensions/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/dylan-lang/collection-extensions/actions/workflows/build-and-test.yml) [![Build documentation](https://github.com/dylan-lang/collection-extensions/actions/workflows/buid-documentation.yml/badge.svg)](https://github.com/dylan-lang/collection-extensions/actions/workflows/buid-documentation.yml)
+
+Collection library for Dylan
+
+## Classes included
+
+- collection-utilities
+- heap
+- sde-vector
+- self-organizing-list
+- sequence-diff
+- sequence-utilities
+- subseq
+- vector-search

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -12,7 +12,7 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../ext/sphinx-extensions/sphinxcontrib'))
+sys.path.insert(0, os.path.abspath('../../_packages/sphinx-extensions/current/src/sphinxcontrib'))
 import dylan.themes as dylan_themes
 
 
@@ -53,7 +53,7 @@ primary_domain = 'dylan'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = dylan_themes.get_html_theme_default()
+html_theme = 'furo'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -71,3 +71,6 @@ html_title = "Collection Extensions"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# Ignore certification verification
+tls_verify = False

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,0 +1,17 @@
+{
+    "category": "utilities",
+    "contact": "dylan-lang@googlegroups.com",
+    "description": "Collection library",
+    "keywords": [
+	"heap", "list", "search", "sequence", "subsequence", "vector", "collections"
+    ],
+    "name": "collection-extensions",
+    "dependencies": [],
+    "dev-dependencies": [
+        "sphinx-extensions@0.2.0",
+        "testworks@3.2"
+    ],
+    "license": "MIT",
+    "url": "https://github.com/dylan-lang/collection-extensions",
+    "version": "0.2.0"
+}

--- a/registry/generic/collection-extensions
+++ b/registry/generic/collection-extensions
@@ -1,1 +1,0 @@
-abstract://dylan/collection-extensions.lid

--- a/registry/generic/collection-extensions-test-suite
+++ b/registry/generic/collection-extensions-test-suite
@@ -1,1 +1,0 @@
-abstract://dylan/tests/collection-extensions-test-suite.lid

--- a/registry/generic/collection-extensions-test-suite-app
+++ b/registry/generic/collection-extensions-test-suite-app
@@ -1,1 +1,0 @@
-abstract://dylan/tests/collection-extensions-test-suite-app.lid


### PR DESCRIPTION
Adapt to 'dylan-tool':

- Add package description (Fix #11) 
    - Use version according to documentation version
- Remove sphinx-extensions submodule (Fix #5)
- Remove registry directory
- Update .gitignore (Fix #12) 
    - Ignore backup files 
    - Ignore package cache dirs

Update documentation:

- Add CI to build documents (Fix #8)
- Update sphinx-extensions path
- Set Furo theme as default
- Ignore certification verification

Others:

- Add initial README (Fix #6)
- Add LICENSE (Fix #10)
- Add CI build and test (Fix #7)